### PR TITLE
map.js: Do not reverse geocode coordinates

### DIFF
--- a/js/map.js
+++ b/js/map.js
@@ -85,7 +85,14 @@ jQuery(function($) {
             self.input_elm.keypress(function(e) {
                 if (e.keyCode == 13) {
                     e.preventDefault();
-                    self.ResolveAddress($(this).val());
+                    if(/[a-zA-Z]/.test(($(this).val()))){
+                        self.ResolveAddress($(this).val());
+                    } else {
+                        var coords = $(this).val().split(/[\s,]+/);
+                        var newPosition = new google.maps.LatLng(coords[0], coords[1]);
+                        self.map.setCenter(newPosition);
+                        self.UpdateUI(newPosition.lat(), newPosition.lng(), $(this).val());
+                    }
                 }
             });
 


### PR DESCRIPTION
At present entered coordinates are reverse geocoded, which leads to improper map placement if Google does not have an exact match.  This pull request adds a check to map.js that if a coordinate is entered, the coordinates are used directly instead of passing the entry to ResolveAddress.
